### PR TITLE
Fixed #12: `home.html` can render post preview without displaying HTML tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "core"
 version = "0.1.0"
 description = ""
-authors = ["Chien Chuan Wang <chien@chienchuan.com>"]
+authors = ["chienchuanw <chienchuanwww@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -20,7 +20,7 @@
 					<span class="text-sm">{{ post.published_at|date }}</span>
 				</div>
 				<h2 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 "><a href="{% url "posts:detail" post.slug %}">{{ post.title }}</a></h2>
-				<p class="mb-5 font-light text-gray-500">{{ post.content|truncate:100 }}</p>
+				<p class="mb-5 font-light text-gray-500">{{ post.content|markdown|striptags|truncate:100 }}</p>
 				<div class="flex justify-between items-center">
 					<div class="flex items-center space-x-4">
 						{% comment %} <img class="w-7 h-7 rounded-full" src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/avatars/bonnie-green.png" alt="Bonnie Green avatar" /> {% endcomment %}


### PR DESCRIPTION
1. Added built-in filter `striptags` in `home.html` and fixed the issue
![Screenshot 2024-07-07 at 4 22 31 PM](https://github.com/chienchuanw/django-blog/assets/45137950/1023919e-250c-4571-9554-0e9505ce9951)
